### PR TITLE
fix(crypto): reset Blowfish state for isolated operations

### DIFF
--- a/internal/crypto/mus_blowfish.go
+++ b/internal/crypto/mus_blowfish.go
@@ -421,19 +421,15 @@ func (b *Blowfish) clearState() {
 }
 
 func (b *Blowfish) Encrypt(inBuffer []byte) []byte {
-	if b.lastOperation != kEncrypt {
-		b.clearState()
-		b.lastOperation = kEncrypt
-	}
+	b.clearState()
+	b.lastOperation = kEncrypt
 
 	return b.mungeData(inBuffer, kEncrypt)
 }
 
 func (b *Blowfish) Decrypt(inBuffer []byte) []byte {
-	if b.lastOperation != kDecrypt {
-		b.clearState()
-		b.lastOperation = kDecrypt
-	}
+	b.clearState()
+	b.lastOperation = kDecrypt
 
 	return b.mungeData(inBuffer, kDecrypt)
 }


### PR DESCRIPTION
- Clear state at start of each Encrypt/Decrypt operation
- Prevents state contamination between isolated message blocks
- Ensures consistent results for consecutive decrypt operations
- Safe for single-block message protocol usage