### PR TITLE
refactor: test-suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,28 @@
 TEST_PKGS = ./_tests/config/... ./_tests/domain/... ./_tests/factory/... ./_tests/adapters/...
 
-.PHONY: test test-v test-cover test-run build run migration queue script job
+.PHONY: test test-unit test-integration test-v test-cover test-run thirdparties-up thirdparties-down build run migration queue script job
 
+# Unit + integration. Brings up the third-party services (Postgres/Redis/RabbitMQ)
+# via Docker, then runs everything.
 test:
-	go test $(TEST_PKGS)
+	./scripts/run-tests.sh --all
 
+# Unit tests only — fast, no Docker required.
+test-unit:
+	./scripts/run-tests.sh --unit
+
+# Integration tests only — brings up the third-party services via Docker.
+test-integration:
+	./scripts/run-tests.sh --integration
+
+# Start / stop the third-party services without running any tests.
+thirdparties-up:
+	./docker/thirdparties/run-thirdparties-docker.sh
+
+thirdparties-down:
+	./docker/thirdparties/run-thirdparties-docker.sh --stop
+
+# The -v / -cover / -run helpers target the unit suite for quick iteration.
 test-v:
 	go test $(TEST_PKGS) -v
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,22 @@ make run                # start the server
 ## Commands
 
 ```bash
-make test               # run all tests
-make test-v             # tests with verbose output
-make test-cover         # tests with a coverage report
-make test-run T=Name    # run a specific test by name
+make test               # unit + integration (starts Docker third-party services)
+make test-unit          # unit tests only (fast, no Docker)
+make test-integration   # integration tests only (starts Docker third-party services)
+make test-v             # unit tests with verbose output
+make test-cover         # unit tests with a coverage report
+make test-run T=Name    # run a specific unit test by name
+make thirdparties-up    # start the third-party services (Postgres/Redis/RabbitMQ)
+make thirdparties-down  # stop them
 make build              # build to bin/gameserver
 make run                # run the server
 ```
+
+Integration tests (build tag `integration`) run against **real** Postgres, Redis,
+and RabbitMQ brought up via Docker — see [`docker/thirdparties/`](docker/thirdparties/).
+If a default port is already in use locally, override it in
+`docker/thirdparties/custom_settings.env`. Unit tests need no Docker.
 
 ## Configuration
 

--- a/_tests/adapters/outbound/integration_test.go
+++ b/_tests/adapters/outbound/integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+// Integration tests run against real Postgres/Redis/RabbitMQ servers brought up
+// by docker/thirdparties. They compile only under `-tags=integration` and each
+// has "Integration" in its name so the runner can target them with -run.
+//
+// Connection details come from TEST_* env vars (set by scripts/run-tests.sh from
+// docker/thirdparties/custom_settings.env); the defaults below match that file,
+// so `go test -tags=integration ./...` works out of the box once the services
+// are up. If a service is unreachable the test skips with a hint rather than
+// failing, so a tagged run on a machine without the services degrades cleanly.
+package outbound_test
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"fsos-server/internal/adapters/outbound"
+)
+
+// runNonce namespaces every Redis key to this test run, so re-running the suite
+// against a persistent Redis (a container not recreated between runs) never
+// trips over keys left by a previous run. CI uses a fresh container each time;
+// this just makes local reruns robust too.
+var runNonce = strconv.FormatInt(time.Now().UnixNano(), 36)
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func pgDSN() string {
+	return envOr("TEST_POSTGRES_DSN", "postgres://postgres:my_secret_pw@127.0.0.1:5432/musgo_regression?sslmode=disable")
+}
+
+func redisAddr() string     { return envOr("TEST_REDIS_ADDR", "127.0.0.1:6379") }
+func redisPassword() string { return os.Getenv("TEST_REDIS_PASSWORD") }
+func redisDB() int          { n, _ := strconv.Atoi(envOr("TEST_REDIS_DB", "0")); return n }
+
+// safeName turns a test name into a Redis-key-safe, unique-per-test prefix so
+// tests sharing one server don't collide.
+func safeName(t *testing.T) string {
+	return strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+}
+
+func newRedisCache(t *testing.T) *outbound.RedisCache {
+	t.Helper()
+	c, err := outbound.NewRedisCache(redisAddr(), redisPassword(), redisDB(), "musgotest:"+runNonce+":cache:"+safeName(t))
+	if err != nil {
+		t.Skipf("redis not reachable at %s (run 'make thirdparties-up'): %v", redisAddr(), err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func newRedisQueue(t *testing.T) *outbound.RedisQueue {
+	t.Helper()
+	q, err := outbound.NewRedisQueue(redisAddr(), redisPassword(), redisDB(), "musgotest:"+runNonce+":queue:"+safeName(t))
+	if err != nil {
+		t.Skipf("redis not reachable at %s (run 'make thirdparties-up'): %v", redisAddr(), err)
+	}
+	t.Cleanup(func() { _ = q.Close() })
+	return q
+}
+
+func newRedisSessionStore(t *testing.T) *outbound.RedisSessionStore {
+	t.Helper()
+	s, err := outbound.NewRedisSessionStore(redisAddr(), redisPassword(), redisDB(), "musgotest:"+runNonce+":sess:"+safeName(t), 3600)
+	if err != nil {
+		t.Skipf("redis not reachable at %s (run 'make thirdparties-up'): %v", redisAddr(), err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func newRabbitMQ(t *testing.T) *outbound.RabbitMQQueue {
+	t.Helper()
+	q, err := outbound.NewRabbitMQQueue(
+		envOr("TEST_RABBITMQ_HOST", "127.0.0.1"),
+		envOr("TEST_RABBITMQ_PORT", "5672"),
+		envOr("TEST_RABBITMQ_USER", "guest"),
+		envOr("TEST_RABBITMQ_PASSWORD", "guest"),
+		envOr("TEST_RABBITMQ_VHOST", "/"),
+		"musgo_test_exchange",
+	)
+	if err != nil {
+		t.Skipf("rabbitmq not reachable (run 'make thirdparties-up'): %v", err)
+	}
+	t.Cleanup(func() { _ = q.Close() })
+	return q
+}

--- a/_tests/adapters/outbound/postgres_integration_test.go
+++ b/_tests/adapters/outbound/postgres_integration_test.go
@@ -1,0 +1,325 @@
+//go:build integration
+
+package outbound_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"fsos-server/external/migrations"
+	"fsos-server/internal/adapters/outbound"
+	"fsos-server/internal/domain/ports"
+	"fsos-server/internal/domain/services"
+	"fsos-server/internal/domain/types/lingo"
+)
+
+// WARNING: newTestPG resets the target database (drops the schema tables) on
+// every test — docker/thirdparties points at a throwaway DB, never a real one.
+
+func newTestPG(t *testing.T) *outbound.PostgresDB {
+	t.Helper()
+	db, err := outbound.NewPostgresDB(pgDSN())
+	if err != nil {
+		t.Skipf("postgres not reachable (run 'make thirdparties-up'): %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	resetPGSchema(t, db)
+
+	runner := services.NewMigrationRunner(db, db, migrations.All)
+	if _, err := runner.RunPending(); err != nil {
+		t.Fatalf("failed to run migrations: %v", err)
+	}
+	return db
+}
+
+// resetPGSchema drops every table the suite may have created and clears the
+// migration ledger so the migrations re-run against a clean slate.
+func resetPGSchema(t *testing.T, db *outbound.PostgresDB) {
+	t.Helper()
+	for _, tbl := range []string{
+		"tx_test", "bans", "player_attributes", "application_attributes", "users", "applications",
+	} {
+		if err := db.DropTable(tbl); err != nil {
+			t.Fatalf("failed to drop %s: %v", tbl, err)
+		}
+	}
+	if _, err := db.QueryBuilder().Table("migrations").Delete(); err != nil {
+		t.Fatalf("failed to clear migrations ledger: %v", err)
+	}
+}
+
+// --- DBAdmin / applications ---
+
+func TestIntegrationPostgres_CreateApplication_Duplicate(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateApplication("testApp"))
+	if err := db.CreateApplication("testApp"); err == nil {
+		t.Error("expected error for duplicate application")
+	}
+}
+
+func TestIntegrationPostgres_DeleteApplication_CascadesAttributes(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateApplication("app1"))
+	mustNoErr(t, db.SetApplicationAttribute("app1", "key", lingo.NewLInteger(1)))
+	mustNoErr(t, db.SetPlayerAttribute("app1", "user1", "score", lingo.NewLInteger(100)))
+	mustNoErr(t, db.DeleteApplication("app1"))
+
+	mustNoErr(t, db.CreateApplication("app1"))
+	got, err := db.GetApplicationAttribute("app1", "key")
+	mustNoErr(t, err)
+	if got.GetType() != lingo.VtVoid {
+		t.Error("application attributes should have cascaded on delete")
+	}
+	got2, err := db.GetPlayerAttribute("app1", "user1", "score")
+	mustNoErr(t, err)
+	if got2.GetType() != lingo.VtVoid {
+		t.Error("player attributes should have cascaded on delete")
+	}
+}
+
+// --- attributes ---
+
+func TestIntegrationPostgres_ApplicationAttribute_SetGetOverwrite(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateApplication("app1"))
+
+	mustNoErr(t, db.SetApplicationAttribute("app1", "val", lingo.NewLInteger(42)))
+	got, err := db.GetApplicationAttribute("app1", "val")
+	mustNoErr(t, err)
+	if got.GetType() != lingo.VtInteger || got.ToInteger() != 42 {
+		t.Fatalf("want integer 42, got type %d value %d", got.GetType(), got.ToInteger())
+	}
+
+	mustNoErr(t, db.SetApplicationAttribute("app1", "val", lingo.NewLString("updated")))
+	got, err = db.GetApplicationAttribute("app1", "val")
+	mustNoErr(t, err)
+	if got.GetType() != lingo.VtString {
+		t.Fatalf("want string after overwrite, got type %d", got.GetType())
+	}
+
+	names, err := db.GetApplicationAttributeNames("app1")
+	mustNoErr(t, err)
+	if len(names) != 1 || names[0] != "val" {
+		t.Fatalf("want [val], got %v", names)
+	}
+
+	mustNoErr(t, db.DeleteApplicationAttribute("app1", "val"))
+	got, err = db.GetApplicationAttribute("app1", "val")
+	mustNoErr(t, err)
+	if got.GetType() != lingo.VtVoid {
+		t.Error("attribute should be gone after delete")
+	}
+}
+
+func TestIntegrationPostgres_PlayerAttribute_SetGet(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateApplication("app1"))
+	mustNoErr(t, db.SetPlayerAttribute("app1", "u1", "score", lingo.NewLInteger(7)))
+
+	got, err := db.GetPlayerAttribute("app1", "u1", "score")
+	mustNoErr(t, err)
+	if got.ToInteger() != 7 {
+		t.Fatalf("want 7, got %d", got.ToInteger())
+	}
+}
+
+func TestIntegrationPostgres_ApplicationAttribute_UnknownApp(t *testing.T) {
+	db := newTestPG(t)
+	if err := db.SetApplicationAttribute("nope", "k", lingo.NewLInteger(1)); err == nil {
+		t.Error("expected error setting attribute on unknown application")
+	}
+}
+
+// --- users ---
+
+func TestIntegrationPostgres_User_Lifecycle(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateUser("alice", "hash", 20))
+
+	u, err := db.GetUser("alice")
+	mustNoErr(t, err)
+	if u.Username != "alice" || u.UserLevel != 20 || u.UUID == "" {
+		t.Fatalf("unexpected user: %+v", u)
+	}
+	if u.CreatedAt.IsZero() {
+		t.Error("created_at should be populated by the now() default")
+	}
+
+	mustNoErr(t, db.UpdateUserLevel("alice", 80))
+	mustNoErr(t, db.UpdateUserPassword("alice", "newhash"))
+	u, err = db.GetUser("alice")
+	mustNoErr(t, err)
+	if u.UserLevel != 80 || u.PasswordHash != "newhash" {
+		t.Fatalf("update not applied: %+v", u)
+	}
+
+	mustNoErr(t, db.DeleteUser("alice"))
+	if _, err := db.GetUser("alice"); !errors.Is(err, ports.ErrUserNotFound) {
+		t.Fatalf("want ErrUserNotFound, got %v", err)
+	}
+}
+
+func TestIntegrationPostgres_User_NotFoundErrors(t *testing.T) {
+	db := newTestPG(t)
+	if err := db.UpdateUserLevel("ghost", 1); !errors.Is(err, ports.ErrUserNotFound) {
+		t.Errorf("UpdateUserLevel: want ErrUserNotFound, got %v", err)
+	}
+	if err := db.DeleteUser("ghost"); !errors.Is(err, ports.ErrUserNotFound) {
+		t.Errorf("DeleteUser: want ErrUserNotFound, got %v", err)
+	}
+}
+
+// --- bans ---
+
+func TestIntegrationPostgres_Ban_ByUserAndRevoke(t *testing.T) {
+	db := newTestPG(t)
+	mustNoErr(t, db.CreateUser("bob", "hash", 20))
+	u, err := db.GetUser("bob")
+	mustNoErr(t, err)
+
+	mustNoErr(t, db.CreateBan(&u.ID, nil, "cheating", nil))
+	ban, err := db.GetActiveBanByUserID(u.ID)
+	mustNoErr(t, err)
+	if ban.Reason != "cheating" || ban.UserID == nil || *ban.UserID != u.ID {
+		t.Fatalf("unexpected ban: %+v", ban)
+	}
+
+	mustNoErr(t, db.RevokeBan(ban.ID))
+	if _, err := db.GetActiveBanByUserID(u.ID); !errors.Is(err, ports.ErrBanNotFound) {
+		t.Fatalf("want ErrBanNotFound after revoke, got %v", err)
+	}
+}
+
+func TestIntegrationPostgres_Ban_ByIP_Expired(t *testing.T) {
+	db := newTestPG(t)
+	ip := "10.0.0.1"
+
+	past := time.Now().Add(-time.Hour)
+	mustNoErr(t, db.CreateBan(nil, &ip, "temp", &past))
+	if _, err := db.GetActiveBanByIP(ip); !errors.Is(err, ports.ErrBanNotFound) {
+		t.Fatalf("expired ban should not be active, got %v", err)
+	}
+
+	future := time.Now().Add(time.Hour)
+	mustNoErr(t, db.CreateBan(nil, &ip, "active", &future))
+	ban, err := db.GetActiveBanByIP(ip)
+	mustNoErr(t, err)
+	if ban.IPAddress == nil || *ban.IPAddress != ip {
+		t.Fatalf("unexpected ban: %+v", ban)
+	}
+}
+
+// --- schema + query builder ---
+
+func TestIntegrationPostgres_Schema_And_QueryBuilder(t *testing.T) {
+	db := newTestPG(t)
+	qb := db.QueryBuilder()
+
+	mustNoErr(t, db.CreateApplication("a1"))
+	mustNoErr(t, db.CreateApplication("a2"))
+
+	count, err := qb.Table("applications").Count()
+	mustNoErr(t, err)
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+
+	row, err := qb.Table("applications").Where("name", "a1").First()
+	mustNoErr(t, err)
+	if row == nil || row["name"] != "a1" {
+		t.Fatalf("first = %v, want name a1", row)
+	}
+
+	mustNoErr(t, db.CreateUser("carol", "hash", 20))
+	affected, err := qb.Table("users").Where("username", "carol").Update(map[string]interface{}{"user_level": 80})
+	mustNoErr(t, err)
+	if affected != 1 {
+		t.Fatalf("update affected = %d, want 1", affected)
+	}
+	row, err = qb.Table("users").Where("username", "carol").Where("user_level", 80).First()
+	mustNoErr(t, err)
+	if row == nil {
+		t.Fatal("expected chained-where row after update")
+	}
+	if level, ok := row["user_level"].(int64); !ok || level != 80 {
+		t.Fatalf("user_level = %v (%T), want int64 80", row["user_level"], row["user_level"])
+	}
+
+	deleted, err := qb.Table("applications").Where("name", "a2").Delete()
+	mustNoErr(t, err)
+	if deleted != 1 {
+		t.Fatalf("delete affected = %d, want 1", deleted)
+	}
+
+	if _, err := qb.Table("bad name!").Count(); err == nil {
+		t.Error("expected error for invalid table name")
+	}
+}
+
+// --- transactions ---
+
+func createPGTxTable(t *testing.T, db *outbound.PostgresDB) {
+	t.Helper()
+	err := db.CreateTable(ports.Table{
+		Name: "tx_test",
+		Columns: []ports.Column{
+			ports.Col("k", ports.ColText).NotNull(),
+			ports.Col("v", ports.ColInteger).NotNull().Default(0),
+		},
+		PrimaryKeys: []string{"k"},
+	})
+	if err != nil {
+		t.Fatalf("create tx_test: %v", err)
+	}
+}
+
+func TestIntegrationPostgres_Tx_CommitPersists(t *testing.T) {
+	db := newTestPG(t)
+	createPGTxTable(t, db)
+	qb := db.QueryBuilder()
+
+	txqb, ok := qb.(ports.TransactionalQueryBuilder)
+	if !ok {
+		t.Fatal("postgres query builder should be transactional")
+	}
+	tx, err := txqb.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := tx.Table("tx_test").Insert(map[string]interface{}{"k": "a", "v": 1}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	n, err := qb.Table("tx_test").Count()
+	mustNoErr(t, err)
+	if n != 1 {
+		t.Fatalf("after commit want 1 row, got %d", n)
+	}
+}
+
+func TestIntegrationPostgres_Tx_RollbackDiscards(t *testing.T) {
+	db := newTestPG(t)
+	createPGTxTable(t, db)
+	qb := db.QueryBuilder()
+
+	tx, err := qb.(ports.TransactionalQueryBuilder).Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := tx.Table("tx_test").Insert(map[string]interface{}{"k": "a", "v": 1}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	n, err := qb.Table("tx_test").Count()
+	mustNoErr(t, err)
+	if n != 0 {
+		t.Fatalf("after rollback want 0 rows, got %d", n)
+	}
+}

--- a/_tests/adapters/outbound/rabbitmq_queue_integration_test.go
+++ b/_tests/adapters/outbound/rabbitmq_queue_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package outbound_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"fsos-server/internal/adapters/outbound"
+	"fsos-server/internal/domain/ports"
+)
+
+func TestIntegrationRabbitMQ_PublishSubscribe(t *testing.T) {
+	q := newRabbitMQ(t)
+
+	var received ports.QueueMessage
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mustNoErr(t, q.Subscribe("test.rmq", func(msg ports.QueueMessage) {
+		received = msg
+		wg.Done()
+	}))
+	// The binding is set up inside Subscribe; give the broker a moment before publishing.
+	time.Sleep(200 * time.Millisecond)
+	mustNoErr(t, q.Publish("test.rmq", []byte("hello")))
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	if received.Topic != "test.rmq" {
+		t.Errorf("topic = %q, want %q", received.Topic, "test.rmq")
+	}
+	if string(received.Payload) != "hello" {
+		t.Errorf("payload = %q, want %q", received.Payload, "hello")
+	}
+}
+
+func TestIntegrationRabbitMQ_PublishAfterClose(t *testing.T) {
+	q := newRabbitMQ(t)
+	// Cleanup already registers a Close; calling it here too is safe/idempotent
+	// enough for asserting the closed-queue behavior.
+	mustNoErr(t, q.Close())
+
+	if err := q.Publish("test.rmq", []byte("data")); err != outbound.ErrQueueClosed {
+		t.Errorf("Publish after Close: err = %v, want ErrQueueClosed", err)
+	}
+}

--- a/_tests/adapters/outbound/redis_cache_integration_test.go
+++ b/_tests/adapters/outbound/redis_cache_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package outbound_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestIntegrationRedisCache_SetGet(t *testing.T) {
+	c := newRedisCache(t)
+
+	mustNoErr(t, c.Set("key1", []byte("value1"), 0))
+	got, err := c.Get("key1")
+	mustNoErr(t, err)
+	if string(got) != "value1" {
+		t.Errorf("Get = %q, want %q", got, "value1")
+	}
+
+	got, err = c.Get("nonexistent")
+	mustNoErr(t, err)
+	if got != nil {
+		t.Errorf("Get missing = %v, want nil", got)
+	}
+}
+
+func TestIntegrationRedisCache_DeleteAndExists(t *testing.T) {
+	c := newRedisCache(t)
+
+	mustNoErr(t, c.Set("k", []byte("v"), 0))
+	exists, err := c.Exists("k")
+	mustNoErr(t, err)
+	if !exists {
+		t.Error("Exists should be true after Set")
+	}
+
+	mustNoErr(t, c.Delete("k"))
+	exists, err = c.Exists("k")
+	mustNoErr(t, err)
+	if exists {
+		t.Error("Exists should be false after Delete")
+	}
+}
+
+func TestIntegrationRedisCache_TTLExpiry(t *testing.T) {
+	c := newRedisCache(t)
+
+	mustNoErr(t, c.Set("k", []byte("v"), 300*time.Millisecond))
+	got, err := c.Get("k")
+	mustNoErr(t, err)
+	if string(got) != "v" {
+		t.Errorf("Get before expiry = %q, want %q", got, "v")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	got, err = c.Get("k")
+	mustNoErr(t, err)
+	if got != nil {
+		t.Errorf("Get after expiry = %v, want nil", got)
+	}
+}
+
+func TestIntegrationRedisCache_SetOps(t *testing.T) {
+	c := newRedisCache(t)
+
+	// empty set
+	members, err := c.SetMembers("myset")
+	mustNoErr(t, err)
+	if len(members) != 0 {
+		t.Errorf("SetMembers on empty = %v, want []", members)
+	}
+
+	mustNoErr(t, c.SetAdd("myset", "a"))
+	mustNoErr(t, c.SetAdd("myset", "b"))
+	mustNoErr(t, c.SetAdd("myset", "c"))
+
+	members, err = c.SetMembers("myset")
+	mustNoErr(t, err)
+	sort.Strings(members)
+	if len(members) != 3 || members[0] != "a" || members[1] != "b" || members[2] != "c" {
+		t.Errorf("SetMembers = %v, want [a b c]", members)
+	}
+
+	ok, err := c.SetIsMember("myset", "a")
+	mustNoErr(t, err)
+	if !ok {
+		t.Error("SetIsMember(a) should be true")
+	}
+	ok, err = c.SetIsMember("myset", "z")
+	mustNoErr(t, err)
+	if ok {
+		t.Error("SetIsMember(z) should be false")
+	}
+
+	mustNoErr(t, c.SetRemove("myset", "a"))
+	ok, err = c.SetIsMember("myset", "a")
+	mustNoErr(t, err)
+	if ok {
+		t.Error("SetIsMember(a) should be false after SetRemove")
+	}
+}

--- a/_tests/adapters/outbound/redis_queue_integration_test.go
+++ b/_tests/adapters/outbound/redis_queue_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package outbound_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"fsos-server/internal/domain/ports"
+)
+
+func TestIntegrationRedisQueue_PublishSubscribe(t *testing.T) {
+	q := newRedisQueue(t)
+
+	var received ports.QueueMessage
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mustNoErr(t, q.Subscribe("test.topic", func(msg ports.QueueMessage) {
+		received = msg
+		wg.Done()
+	}))
+	// Give the consumer goroutine a moment to enter its BRPOP before publishing.
+	time.Sleep(100 * time.Millisecond)
+	mustNoErr(t, q.Publish("test.topic", []byte("hello")))
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second): // BRPOP polls at 1s granularity
+		t.Fatal("timed out waiting for message")
+	}
+
+	if received.Topic != "test.topic" {
+		t.Errorf("topic = %q, want %q", received.Topic, "test.topic")
+	}
+	if string(received.Payload) != "hello" {
+		t.Errorf("payload = %q, want %q", received.Payload, "hello")
+	}
+}
+
+func TestIntegrationRedisQueue_Unsubscribe(t *testing.T) {
+	q := newRedisQueue(t)
+
+	var mu sync.Mutex
+	called := false
+	mustNoErr(t, q.Subscribe("topic", func(msg ports.QueueMessage) {
+		mu.Lock()
+		called = true
+		mu.Unlock()
+	}))
+	mustNoErr(t, q.Unsubscribe("topic"))
+
+	mustNoErr(t, q.Publish("topic", []byte("data")))
+	time.Sleep(2 * time.Second) // longer than the 1s poll, so a live consumer would fire
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called {
+		t.Error("handler should not be called after unsubscribe")
+	}
+}

--- a/_tests/adapters/outbound/redis_session_store_integration_test.go
+++ b/_tests/adapters/outbound/redis_session_store_integration_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package outbound_test
+
+import (
+	"testing"
+
+	"fsos-server/internal/domain/ports"
+)
+
+// The Redis session store runs the same behavioral helpers as the in-memory
+// store (session_store_test.go), against a real Redis. Each subtest gets a fresh
+// store with a unique key prefix (via newRedisSessionStore -> safeName), so they
+// don't collide on the shared server.
+func TestIntegrationRedisSessionStore(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func(*testing.T, ports.SessionStore)
+	}{
+		{"RegisterConnection", testRegisterConnection},
+		{"IsConnected", testIsConnected},
+		{"GetAllConnections", testGetAllConnections},
+		{"UnregisterConnection_CleansEverything", testUnregisterConnection_CleansEverything},
+		{"SessionAttribute_SetGetDelete", testSessionAttribute_SetGetDelete},
+		{"SessionAttribute_Float", testSessionAttribute_Float},
+		{"SessionAttribute_String", testSessionAttribute_String},
+		{"SessionAttribute_Symbol", testSessionAttribute_Symbol},
+		{"JoinRoom_And_GetMembers", testJoinRoom_And_GetMembers},
+		{"LeaveRoom", testLeaveRoom},
+		{"GetClientRooms", testGetClientRooms},
+		{"LeaveAllRooms", testLeaveAllRooms},
+		{"GetConnection_NonExistent", testGetConnection_NonExistent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fn(t, newRedisSessionStore(t))
+		})
+	}
+}

--- a/_tests/factory/database_integration_test.go
+++ b/_tests/factory/database_integration_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package factory_test
+
+import (
+	"os"
+	"testing"
+
+	"fsos-server/internal/factory"
+)
+
+// Runs against the Postgres brought up by docker/thirdparties. The DSN defaults
+// to that stack; scripts/run-tests.sh sets TEST_POSTGRES_DSN from
+// custom_settings.env.
+func TestNewDatabase_PostgresIntegration(t *testing.T) {
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		dsn = "postgres://postgres:my_secret_pw@127.0.0.1:5432/musgo_regression?sslmode=disable"
+	}
+
+	result, err := factory.NewDatabase("postgres", dsn, nil)
+	if err != nil {
+		t.Skipf("postgres not reachable (run 'make thirdparties-up'): %v", err)
+	}
+	defer result.Adapter.Close()
+
+	if result.Adapter == nil || result.MigrationRunner == nil || result.QueryBuilder == nil {
+		t.Error("database result should be fully populated")
+	}
+}

--- a/docker/thirdparties/README.md
+++ b/docker/thirdparties/README.md
@@ -1,0 +1,49 @@
+# Third-party services for integration tests
+
+The integration test suites (`//go:build integration`) run against **real**
+Postgres, Redis, and RabbitMQ instances — no mocks. This directory brings those
+up with Docker, following the same shape as Apache Doris' `docker/thirdparties`:
+one compose file per service, selectable, driven by a single settings file.
+
+## Layout
+
+```
+docker/thirdparties/
+├── custom_settings.env        # ports/credentials — single source of truth
+├── run-thirdparties-docker.sh # start/stop the services
+└── docker-compose/
+    ├── postgres/postgres.yaml
+    ├── redis/redis.yaml
+    └── rabbitmq/rabbitmq.yaml
+```
+
+## Usage
+
+```bash
+# start everything (waits until healthy)
+./docker/thirdparties/run-thirdparties-docker.sh
+# or a subset
+./docker/thirdparties/run-thirdparties-docker.sh -c redis,rabbitmq
+# stop + remove (with volumes)
+./docker/thirdparties/run-thirdparties-docker.sh --stop
+```
+
+You normally don't call it directly — the test runner does:
+
+```bash
+make test              # unit + integration (starts services automatically)
+make test-unit         # unit only, no Docker
+make test-integration  # integration only (starts services)
+make thirdparties-up   # just start the services
+make thirdparties-down # stop them
+```
+
+## Configuration
+
+Edit `custom_settings.env` to change ports/credentials (e.g. if `5432` is already
+taken locally). `scripts/run-tests.sh` derives the `TEST_*` env vars the Go
+suites read from these same values, so you only change them in one place.
+Anything already exported in the environment (e.g. in CI) wins over the file.
+
+Data is ephemeral: Postgres runs on a tmpfs and Redis persistence is disabled,
+so every `up` starts clean.

--- a/docker/thirdparties/custom_settings.env
+++ b/docker/thirdparties/custom_settings.env
@@ -1,0 +1,23 @@
+# Connection settings for the third-party services the integration tests run
+# against. run-thirdparties-docker.sh feeds this to docker compose (--env-file),
+# and scripts/run-tests.sh derives the TEST_* env vars the Go suites read from
+# these same values — so this file is the single source of truth.
+#
+# Override any of these (e.g. if a port is already taken locally) and re-run.
+
+MUS_CONTAINER_PREFIX=musgo
+
+# Postgres
+MUS_PG_PORT=5432
+MUS_PG_USER=postgres
+MUS_PG_PASSWORD=my_secret_pw
+MUS_PG_DB=musgo_regression
+
+# Redis
+MUS_REDIS_PORT=6379
+
+# RabbitMQ
+MUS_RABBITMQ_PORT=5672
+MUS_RABBITMQ_MGMT_PORT=15672
+MUS_RABBITMQ_USER=guest
+MUS_RABBITMQ_PASSWORD=guest

--- a/docker/thirdparties/docker-compose/postgres/postgres.yaml
+++ b/docker/thirdparties/docker-compose/postgres/postgres.yaml
@@ -1,0 +1,20 @@
+# Postgres service for the integration test suite.
+# Ports/credentials are driven by ../../custom_settings.env (via --env-file).
+services:
+  musgo-postgres:
+    image: postgres:16-alpine
+    container_name: ${MUS_CONTAINER_PREFIX:-musgo}-postgres
+    environment:
+      POSTGRES_USER: ${MUS_PG_USER:-postgres}
+      POSTGRES_PASSWORD: ${MUS_PG_PASSWORD:-my_secret_pw}
+      POSTGRES_DB: ${MUS_PG_DB:-musgo_regression}
+    ports:
+      - "${MUS_PG_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${MUS_PG_USER:-postgres} -d ${MUS_PG_DB:-musgo_regression}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      # ephemeral storage — each `up` starts from a clean database
+      - /var/lib/postgresql/data

--- a/docker/thirdparties/docker-compose/rabbitmq/rabbitmq.yaml
+++ b/docker/thirdparties/docker-compose/rabbitmq/rabbitmq.yaml
@@ -1,0 +1,16 @@
+# RabbitMQ service (with management UI) for the integration test suite.
+services:
+  musgo-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: ${MUS_CONTAINER_PREFIX:-musgo}-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${MUS_RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${MUS_RABBITMQ_PASSWORD:-guest}
+    ports:
+      - "${MUS_RABBITMQ_PORT:-5672}:5672"
+      - "${MUS_RABBITMQ_MGMT_PORT:-15672}:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30

--- a/docker/thirdparties/docker-compose/redis/redis.yaml
+++ b/docker/thirdparties/docker-compose/redis/redis.yaml
@@ -1,0 +1,13 @@
+# Redis service for the integration test suite.
+services:
+  musgo-redis:
+    image: redis:7-alpine
+    container_name: ${MUS_CONTAINER_PREFIX:-musgo}-redis
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "${MUS_REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Bring up (default) or tear down the third-party services that the integration
+# test suites run against: Postgres, Redis, RabbitMQ.
+#
+# Mirrors the Apache Doris docker/thirdparties approach: one compose file per
+# service, selectable, driven by custom_settings.env. The Go integration suites
+# connect to whatever this script starts.
+#
+# Usage:
+#   run-thirdparties-docker.sh                    # start all
+#   run-thirdparties-docker.sh -c redis,rabbitmq  # start a subset
+#   run-thirdparties-docker.sh --stop             # stop + remove all (with volumes)
+#   run-thirdparties-docker.sh -c postgres --stop # stop a subset
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_DIR="$SCRIPT_DIR/docker-compose"
+ENV_FILE="$SCRIPT_DIR/custom_settings.env"
+PROJECT_PREFIX="${MUS_COMPOSE_PROJECT:-musgo-tp}"
+
+ALL=(postgres redis rabbitmq)
+components=""
+action="up"
+
+usage() { sed -n '2,15p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -c|--components) components="${2:-}"; shift 2 ;;
+    --stop|--down)   action="down"; shift ;;
+    -h|--help)       usage; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+# Pick the available compose command (v2 plugin preferred).
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "error: neither 'docker compose' nor 'docker-compose' is installed" >&2
+  exit 1
+fi
+
+if [ -n "$components" ]; then
+  IFS=',' read -r -a SELECTED <<< "$components"
+else
+  SELECTED=("${ALL[@]}")
+fi
+
+for comp in "${SELECTED[@]}"; do
+  file="$COMPOSE_DIR/$comp/$comp.yaml"
+  if [ ! -f "$file" ]; then
+    echo "error: no compose file for component '$comp' ($file)" >&2
+    exit 1
+  fi
+  project="${PROJECT_PREFIX}-${comp}"
+  if [ "$action" = "down" ]; then
+    echo ">> stopping $comp"
+    "${DC[@]}" -p "$project" -f "$file" --env-file "$ENV_FILE" down -v
+  else
+    echo ">> starting $comp (waiting until healthy)"
+    "${DC[@]}" -p "$project" -f "$file" --env-file "$ENV_FILE" up -d --wait
+  fi
+done
+
+if [ "$action" = "up" ]; then
+  echo ""
+  echo "third-party services are up. Connection settings: $ENV_FILE"
+  echo "Run the integration suite with: make test-integration"
+fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Test runner with three modes:
+#   --unit          only unit tests (fast, no Docker)
+#   --integration   only integration tests (brings up third-party services)
+#   --all (default) unit + integration
+#
+# Integration tests live behind the `integration` build tag and have
+# "Integration" in their name; the --integration mode filters on that so unit
+# tests aren't re-run.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TP="$ROOT/docker/thirdparties"
+ENV_FILE="$TP/custom_settings.env"
+
+TEST_PKGS=(./_tests/config/... ./_tests/domain/... ./_tests/factory/... ./_tests/adapters/...)
+INTEGRATION_RUN='Integration'
+
+mode="all"
+case "${1:-}" in
+  --unit)         mode="unit" ;;
+  --integration)  mode="integration" ;;
+  --all|"")       mode="all" ;;
+  -h|--help)      echo "Usage: $(basename "$0") [--unit|--integration|--all]"; exit 0 ;;
+  *) echo "error: unknown argument '$1'" >&2; exit 1 ;;
+esac
+
+cd "$ROOT"
+
+if [ "$mode" = "unit" ]; then
+  exec go test "${TEST_PKGS[@]}"
+fi
+
+# integration / all: make sure the third-party services are running.
+"$TP/run-thirdparties-docker.sh"
+
+# Derive the TEST_* connection env the Go suites read from custom_settings.env
+# (already-set env wins, so CI can override without editing the file).
+set -a
+# shellcheck disable=SC1090
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+set +a
+
+export TEST_POSTGRES_DSN="${TEST_POSTGRES_DSN:-postgres://${MUS_PG_USER:-postgres}:${MUS_PG_PASSWORD:-my_secret_pw}@127.0.0.1:${MUS_PG_PORT:-5432}/${MUS_PG_DB:-musgo_regression}?sslmode=disable}"
+export TEST_REDIS_ADDR="${TEST_REDIS_ADDR:-127.0.0.1:${MUS_REDIS_PORT:-6379}}"
+export TEST_RABBITMQ_HOST="${TEST_RABBITMQ_HOST:-127.0.0.1}"
+export TEST_RABBITMQ_PORT="${TEST_RABBITMQ_PORT:-${MUS_RABBITMQ_PORT:-5672}}"
+export TEST_RABBITMQ_USER="${TEST_RABBITMQ_USER:-${MUS_RABBITMQ_USER:-guest}}"
+export TEST_RABBITMQ_PASSWORD="${TEST_RABBITMQ_PASSWORD:-${MUS_RABBITMQ_PASSWORD:-guest}}"
+export TEST_RABBITMQ_VHOST="${TEST_RABBITMQ_VHOST:-/}"
+
+if [ "$mode" = "integration" ]; then
+  exec go test -tags=integration -run "$INTEGRATION_RUN" "${TEST_PKGS[@]}"
+fi
+
+# all
+exec go test -tags=integration "${TEST_PKGS[@]}"


### PR DESCRIPTION
…rties

Add a Doris-style docker/thirdparties harness — one docker-compose file per service plus run-thirdparties-docker.sh — that brings up real Postgres, Redis and RabbitMQ, and a scripts/run-tests.sh with --unit/--integration/--all modes wired into the Makefile:

  make test              unit + integration (starts the services)
  make test-unit         unit only, no Docker
  make test-integration  integration only (starts the services)

Integration tests sit behind the `integration` build tag with "Integration" in their name (so --integration can target them via -run), and skip with a hint when a service is unreachable. New suites exercise the Redis cache/queue/session-store and the RabbitMQ queue against live servers, mirroring the in-memory behavioral tests; the Postgres integration tests move out of the env-gated unit file into the tagged suite, leaving only the no-server construction tests in the unit build. Redis keys are namespaced per run so reruns against a persistent server stay isolated.

Connection settings live in docker/thirdparties/custom_settings.env, from which run-tests.sh derives the TEST_* env the suites read.